### PR TITLE
add support for Mac

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,6 +186,10 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.2-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.15.2-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.15.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.23.0)
@@ -258,6 +262,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.3-aarch64-linux)
+    sqlite3 (1.6.3-arm64-darwin)
     sqlite3 (1.6.3-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -291,6 +297,8 @@ GEM
     zeitwerk (2.6.8)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Trying to docker up this project on Mac throws this error.

![image](https://github.com/mtantawy/job-hunt-tracker/assets/8272048/98417f28-e0cb-46da-b77a-2e5b85c6afce)

To resolve this issue and ensure smooth Docker image setup for Mac users, it's necessary to include the Mac platform in the gem lock file. This can be achieved by executing the following command:

```
bundle lock --add-platform aarch64-linux 
```